### PR TITLE
clean up list of features

### DIFF
--- a/kempner_hpc_handbook/resource_management/advanced_slurm_features.md
+++ b/kempner_hpc_handbook/resource_management/advanced_slurm_features.md
@@ -59,9 +59,7 @@ kempner_requeue intel,holyhdr,icelake,avx,avx2,avx512,gpu,a100,cc8.0
 kempner_h100 amd,holyndr,genoa,avx,avx2,avx512,gpu,h100,cc9.0
 ```
 
-The following table describes each features in the Kempner HPC cluster, 
-
-Thank you for the clarification. Here's the updated description for `holyndr` in the context of SLURM features, reflecting its relation to network capabilities:
+The following table describes each of the features in the Kempner HPC cluster:
 
 | Feature  | Description                                                                                       |
 |----------|---------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Removes the "Thank you for the clarification" section. Thought the additional sentences weren't required.

Tested by running `jupyter-book build kempner_hpc_handbook` locally and viewing the html output:

<img width="641" alt="Screenshot 2024-03-28 at 5 23 23 PM" src="https://github.com/KempnerInstitute/kempner-hpc-handbook/assets/1408790/72074de1-bace-42b9-bee2-34513962180b">
