### PR TITLE
add basic Ray info

### DIFF
--- a/kempner_hpc_handbook/scalability/distributed_computing.md
+++ b/kempner_hpc_handbook/scalability/distributed_computing.md
@@ -59,9 +59,19 @@ It serves as the backend for a number of tools in the modern AI/ML ecosystem, in
 
 Ray clusters can be run on your laptop as well as on SLURM. The methods of starting the cluster are different, but once the cluster is started the python API is the same, enabling easy development of Ray applications for the cluster on your laptop.
 
+#### Installing Ray
+
+Ray can be installed using pip. The following command will install Ray and all of its dependencies.
+
+```
+pip install ray[default]
+```
+
+While Ray is available on `conda-forge`, the version available there is maintained by the community and may not be the most up to date. It is recommended to install Ray using pip. See the [Ray documentation](https://docs.ray.io/en/latest/ray-overview/installation.html#installing-from-conda-forge) for more information on how to install Ray.
+
 #### Using Ray on SLURM
 
-In order to use ray on SLURM, you will need to start a ray cluster and ensure that it is using the proper number of resources. The following script can be used to start a ray cluster on SLURM. This script will start a ray head on the first node in the allocation and then start ray workers on the rest of the nodes. The script will then start a python script that uses ray to do distributed computation. Note the use of teh SLURM environment variables. By default, Ray will attempt to use all CPUs on a node regardless of the number of tasks requested. This can be controlled by setting the `--num-cpus` flag when starting the ray cluster.
+In order to use Ray on SLURM, you will need to start a Ray cluster and ensure that it is using the proper number of resources. The following script can be used to start a Ray cluster on SLURM. This script will start a Ray head node on the first node in the allocation and then start Ray workers on the rest of the nodes. The script will then start a python script that uses Ray to do distributed computation. Note the use of the SLURM environment variables. By default, Ray will attempt to use all CPUs on a node regardless of the number of tasks requested. This can be controlled by setting the `--num-cpus` flag when starting the Ray cluster.
 
 ```
 #! /bin/bash
@@ -78,8 +88,8 @@ In order to use ray on SLURM, you will need to start a ray cluster and ensure th
 
 
 
-# Load environment with ray installed, as well as other dependencies
-# Can also run ray inside singularitiy containers, assuming that all needed dependencies are installed in the container
+# Load environment with Ray installed, as well as other dependencies
+# Can also run Ray inside singularitiy containers, assuming that all needed dependencies are installed in the container
 module load python
 
 mamba activate fake_ray_environment
@@ -116,6 +126,10 @@ done
 # Start your script here
 python my_ray_script.py
 ```
+
+Your python script will then be able to call `ray.init()` to connect to the Ray cluster and use the Ray API to do distributed computation. Tasks and actors created 
+during your script will run across the Ray cluster, with Ray handling scheduling, communication, and placement. Upon completion of the script, the Ray cluster will be shut down and the resources will be released as SLURM terminates the job.
+
 ### Dask
 [TODO]
 

--- a/kempner_hpc_handbook/scalability/distributed_computing.md
+++ b/kempner_hpc_handbook/scalability/distributed_computing.md
@@ -97,7 +97,7 @@ export head_addr="$head_node_ip:$head_port"
 echo "Head address: $head_addr"
 
 echo "Starting Ray head on $head_node"
-srun -N 1 -n 1 -w "$head_node" ${SINGULARITY_WRAP} ray start --head --node-ip-address="$head_node_ip" \
+srun -N 1 -n 1 -w "$head_node" ray start --head --node-ip-address="$head_node_ip" \
     --port=$head_port --num-cpus $SLURM_CPUS_PER_TASK --num-gpus $SLURM_GPUS_ON_NODE --min-worker-port 20001 --max-worker-port 30000 --block &
 
 # wait for head node to start
@@ -108,7 +108,7 @@ worker_num=$((SLURM_NNODES - 1))
 for (( i = 1; i <= worker_num; i++ )); do
     node=${nodes_array[$i]}
     echo "Starting Ray worker on $node"
-    srun -N 1 -n 1 -w "$node" ${SINGULARITY_WRAP} ray start --address="$head_addr" \
+    srun -N 1 -n 1 -w "$node"  ray start --address="$head_addr" \
         --num-cpus $SLURM_CPUS_PER_TASK --num-gpus $SLURM_GPUS_ON_NODE --min-worker-port 20001 --max-worker-port 30000 --block &
     sleep 5
 done

--- a/kempner_hpc_handbook/scalability/distributed_computing.md
+++ b/kempner_hpc_handbook/scalability/distributed_computing.md
@@ -90,9 +90,8 @@ In order to use Ray on SLURM, you will need to start a Ray cluster and ensure th
 
 # Load environment with Ray installed, as well as other dependencies
 # Can also run Ray inside singularitiy containers, assuming that all needed dependencies are installed in the container
-module load python
 
-mamba activate fake_ray_environment
+## PLACEHOLDER LOAD ENV COMMAND ##
 
 # choose available port on the head node
 head_port=`comm -23 <(seq 15000 20000 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1`

--- a/kempner_hpc_handbook/scalability/distributed_computing.md
+++ b/kempner_hpc_handbook/scalability/distributed_computing.md
@@ -55,7 +55,7 @@ Pytorch and Pytorch lightning support multiple communicatoin backends including 
 
 [Ray](https://ray.io) is a distributed computation library for python that supports both single and multi-node execution. Ray is designed to be easy to use and provides a number of high-level abstractions for distributed computing, including a task-based API, a distributed actor API, and a distributed data API. Ray also includes a number of utilities for distributed machine learning, including a distributed data loader and a distributed hyperparameter search library.
 
-It serves as the backend for a number of tools in the modern AI/ML ecosystem, including [vLLM](), [DCLM]() and others. 
+It serves as the backend for a number of tools in the modern AI/ML ecosystem, including [vLLM](https://github.com/vllm-project/vllm), [DCLM](https://github.com/mlfoundations/dclm) and others. 
 
 Ray clusters can be run on your laptop as well as on SLURM. The methods of starting the cluster are different, but once the cluster is started the python API is the same, enabling easy development of Ray applications for the cluster on your laptop.
 

--- a/kempner_hpc_handbook/scalability/distributed_computing.md
+++ b/kempner_hpc_handbook/scalability/distributed_computing.md
@@ -79,7 +79,7 @@ In order to use Ray on SLURM, you will need to start a Ray cluster and ensure th
 #SBATCH -N 2 # number of nodes, this script is adaptable for any number of nodes
 #SBATCH --tasks-per-node=1
 #SBATCH --cpus-per-task=40 # number of cpus per task, this script can work with any number of cpus
-#SBATCH --gres=gpu:4 # number of gpus per node
+#SBATCH --gres=gpu:4 # number of gpus per node, note that GPUs are not required for Ray
 #SBATCH --mem=0 # memory per node, note that this is per node and not per task
 #SBATCH --time=0:30:00 # time limit for the job
 #SBATCH -p kempner_requeue


### PR DESCRIPTION
PR adding a brief description of Ray, links to documentation, and an example slurm script for starting up a ray cluster.

Intended to serve as a reference for basic usage, more details can be added in the future