### PR TITLE
Changed the login node names.

### DIFF
--- a/kempner_hpc_handbook/development_and_runtime_envs/using_vscode_for_remote_development.md
+++ b/kempner_hpc_handbook/development_and_runtime_envs/using_vscode_for_remote_development.md
@@ -23,19 +23,9 @@ For mac and linux users, the file is located at `~/.ssh/config`. For Windows use
 
 ```bash
 Host cannon
-  HostName holylogin01.rc.fas.harvard.edu
+  HostName login.rc.fas.harvard.edu
   User <username>
 ```
-
-````{warning}
-Please rotate among different login nodes to avoid an unbalanced load on specific nodes. Create multiple connections and change the login node name (e.g., from `holylogin01` to `holylogin02`, `holylogin03`, or `holylogin04`) and connect to a different login node every time. For example, define `cannon02` connection as,
-
-```bash
-Host cannon02
-  HostName holylogin02.rc.fas.harvard.edu
-  User <username>
-```
-````
 
 Please make sure that you use your FASRC username in place of `<username>`.
 

--- a/kempner_hpc_handbook/getting_started/accessing_and_navigating_the_cluster.md
+++ b/kempner_hpc_handbook/getting_started/accessing_and_navigating_the_cluster.md
@@ -59,7 +59,7 @@ For detailed instructions and additional information, please read more about the
 ```
 
 ```{warning}
-Please avoid logging in directly to specific login nodes, as this can disrupt the load balancing on the nodes and may exert undue pressure on a particular login node (e.g., `holylogin01` through `holylogin04`). An exception exists for VSCode, which requires rotation between login nodes. Please refer to the [VSCode Section](development_and_runtime_envs:using_vscode_for_remote_development) for more information.
+Please avoid logging in directly to specific login nodes, as this can disrupt the load balancing on the nodes and may exert undue pressure on a particular login node (e.g., `holylogin05`). Additionally, it can block your access to the cluster if the chosen node is out of service. 
 ```
 
 (ssh_access)=


### PR DESCRIPTION
holylogin01, ...holylogin04 were retired and these should not exist in our document. I removed them from the files "using_vscode_for_remote_development.md" and "accessing_and_navigating_the_cluster.md". 

The handbook refers only to "login.rc.fas.harvard.edu". 